### PR TITLE
upgrade() upgrade gulp-tslint and tslint-config-valorsoft

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "file-loader": "0.8.5",
     "gh-pages": "0.9.0",
     "gulp": "3.9.1",
-    "gulp-tslint": "4.3.1",
+    "gulp-tslint": "5.0.0",
     "html-loader": "0.4.0",
     "html-webpack-plugin": "2.8.1",
     "istanbul-instrumenter-loader": "0.1.3",
@@ -93,7 +93,7 @@
     "shelljs": "0.7.0",
     "source-map-loader": "0.1.5",
     "ts-loader": "0.8.1",
-    "tslint-config-valorsoft": "1.0.2",
+    "tslint-config-valorsoft": "1.0.3",
     "typescript": "1.8.10",
     "typings": "1.0.3",
     "webpack": "1.12.13"


### PR DESCRIPTION
Upgraded gulp-tslint from 4.3.1 to 5.0.0 to avoid version mismatch and make gulp-tslint to work as expected.
Upgraded tslint-config-valorsoft from 1.0.2 to 1.0.3.

`````` before```
![0001](https://cloud.githubusercontent.com/assets/7901557/15394559/56e223ee-1ddc-11e6-96aa-8891bf9a3ee7.png)

```now```
![0002](https://cloud.githubusercontent.com/assets/7901557/15394638/bec00580-1ddc-11e6-81b8-f63c89545f85.png)
``````
