### PR TITLE
Fix header for JP language

### DIFF
--- a/src/common/language/language.service.ts
+++ b/src/common/language/language.service.ts
@@ -235,6 +235,13 @@ export class LanguageService {
     return `&lang=${this.currentLanguage}`;
   }
 
+  public shouldPlacePrepositionsAfter(): boolean {
+    // In Japanese, many prepositions like "of" or "in" must be placed after the word
+    // instead of before. So instead of "A of B", in Japanese you must say
+    // "B {{ 'of' | translate }} A".
+    return this.currentLanguage === 'ja';
+  }
+
   private processTranslation(observer: Observer<any>, translations: any, key: string | string[]): void {
     if (typeof key === 'string') {
       observer.next(translations[key as string]);

--- a/src/shared/header/header.component.html
+++ b/src/shared/header/header.component.html
@@ -32,16 +32,23 @@
           class="filters-container"
           [ngStyle]="{visibility: ((isCountryFilterReady && isThingFilterReady) || (isMapPage && isThingFilterReady)) ? 'visible' : 'hidden'}">
 
-        <things-filter (isFilterGotData)="isFilterGotData($event)"></things-filter>
-
-        <span *ngIf="isMapPage"
+        <span *ngIf="(isMapPage && shouldPlacePrepositionsAfter)"
+              class="map-things-text">{{ 'ON_THE_WORLD_MAP' | translate }}</span>
+        <things-filter *ngIf="!isMatrixPage" (isFilterGotData)="isFilterGotData($event)"></things-filter>
+        <span *ngIf="(isMapPage && !shouldPlacePrepositionsAfter)"
               class="map-things-text">{{ 'ON_THE_WORLD_MAP' | translate }}</span>
 
         <div *ngIf="isMatrixPage"
             class="some-filter-container incomeby">
-          <span class="mobile-ver">{{ 'IN' | translate }}</span>
+          <things-filter *ngIf="!shouldPlacePrepositionsAfter" (isFilterGotData)="isFilterGotData($event)"></things-filter>
+
+          <span *ngIf="!shouldPlacePrepositionsAfter" class="mobile-ver">{{ 'IN' | translate }}</span>
 
           <countries-filter (isFilterGotData)="isFilterGotData($event)"></countries-filter>
+
+          <span *ngIf="shouldPlacePrepositionsAfter" class="mobile-ver">{{ 'IN' | translate }}</span>
+
+          <things-filter *ngIf="shouldPlacePrepositionsAfter" (isFilterGotData)="isFilterGotData($event)"></things-filter>
 
           <span #incomeTitleContainer
                 class="income-title-container">

--- a/src/shared/header/header.component.ts
+++ b/src/shared/header/header.component.ts
@@ -122,6 +122,7 @@ export class HeaderComponent implements OnDestroy, AfterViewInit, OnInit {
   incomeTitleText: string;
   isIncomeFilter: boolean;
   ngSubscriptions: SubscriptionsList = {};
+  shouldPlacePrepositionsAfter: boolean;
   private headerTitle: ElementRef;
 
   constructor(elementRef: ElementRef,
@@ -278,6 +279,7 @@ export class HeaderComponent implements OnDestroy, AfterViewInit, OnInit {
     this.ngSubscriptions.combileTranslations = fromEvent(this.languageService.translationsLoadedEvent, this.languageService.translationsLoadedString)
       .subscribe(( trans: TranslationsInterface ) => {
       this.getTranslations(trans)
+      this.shouldPlacePrepositionsAfter = this.languageService.shouldPlacePrepositionsAfter();
     });
 
     this.ngSubscriptions.routerEvents = this.router.events.subscribe( event => {


### PR DESCRIPTION
Hello, this is Shu, a Japanese translator for Factfulness who just got invited to Gapminder Slack.

There's a translation bug for JP language regarding prepositions like "of" or "in". In Japanese, many prepositions like "of" or "in" must be placed after the word instead of before. So instead of `"A of B"`, in Japanese you must do `"B {{ 'of' | translate }} A"`.

I added the logic on `LanguageService` and used it on the `Header` component. This might not be the best way (as there are many other places that use `{{ 'IN' | translate }}`), but at least fixes the header (the most prominent UI) for the Japanese audience.

## Before (Incorrect)

<img width="711" alt="screen shot 2019-02-13 at 12 37 10 pm" src="https://user-images.githubusercontent.com/992008/52742197-18d43c80-2f8c-11e9-84a5-0f20350a95cc.png">

<img width="499" alt="screen shot 2019-02-13 at 12 37 28 pm" src="https://user-images.githubusercontent.com/992008/52742215-22f63b00-2f8c-11e9-9c4c-ade1545de6df.png">

## After (Correct)

<img width="633" alt="screen shot 2019-02-13 at 12 25 26 pm" src="https://user-images.githubusercontent.com/992008/52742234-2be70c80-2f8c-11e9-8336-7b737fb6f27b.png">

<img width="496" alt="screen shot 2019-02-13 at 12 41 26 pm" src="https://user-images.githubusercontent.com/992008/52742547-ce9f8b00-2f8c-11e9-867c-348531a91376.png">
